### PR TITLE
Úpravy CSS

### DIFF
--- a/pohadka.html
+++ b/pohadka.html
@@ -5,38 +5,31 @@
   <meta charset="utf-8">
   <style>
      
-      .content {
-            width: 800px;
-            margin: auto;
-            border: 5px solid rgb(9, 71, 6);
-            border-top: 10px solid rgb(9, 71, 6);
-           background-color: rgb(230, 230, 230);
-          line-height: 1.5em;
-        } 
+      
+     p.autor, p.zdroj {text-align: right; font-style: italic; font-size: 20px;}
+      
+      body { padding: 5%; height: 100%; background-color:  rgb(230, 230, 230); }
+       
+      
       
       .zanr {
             text-align: center;
             font-size: 30px;
-            color: purple;
+            color: darkgreen;
         } 
       
-      h1 {
-            text-align: center; 
-            font-size: 40px;
-            color: purple; 
-        } 
+      
+            h1    {color: purple; font-size: 300%; border-style: double; border-color: darkgreen; line-height: 150%; text-align: center;}
+      
       
       h2 {
-            padding: 20px;
             font-size: 30px;
             color: purple;
+          text-transform: uppercase;
+          text-align: center;
         }
       
-      .autor {
-            padding: 15px;
-            font-size: 20px;
-            
-        }
+     
       
       .name {
             font-size: 20px;
@@ -45,23 +38,18 @@
             
         }
       
-      .zdroj {
-            font-size: 20px;
-            text-decoration-style: solid;
-            padding: 15px;    
-        }
-      
-      section {
+  section {
             padding: 20px;
             font-size: 20px;
             font-family: "Helvetica", sans-serif;
             text-align: justify;
         }
+
       
       footer {
             text-align: center;
             font-size: 40px;
-            color: purple;
+            color: darkgreen;
             font-style: italic;
         }
       


### PR DESCRIPTION
Rozšíření stránky - v procentech
Odstraněný rámeček kolem stránky.
Změna barvy - žánr, footer
Přidán rámeček - h1
h2 - zarovnány doprostřed, verzálky
autor, zdroj - zarovnáno doprava, kurziva

PS: Velikost a barva písma se mi pro důchodce zdála být OK. Nelíbil se
mi však ten rámeček okolo textu, aby tam byla zachována ta barva, tak
jsem změnila barvu žánru, footeru a udělala rámeček u nadpisu. Velikost
stránky jsem udělala v procentech, aby se to na různých rozměrech
obrazovek přizpůsobovalo.
